### PR TITLE
update from pegdown to markedj

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -25,7 +25,7 @@ object MyBuild extends Build {
       "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
     ),
     libraryDependencies ++= Seq(
-      "gitbucket"          % "gitbucket-assembly" % "3.5.0" % "provided",
+      "gitbucket"          % "gitbucket-assembly" % "3.7.0" % "provided",
       "com.typesafe.play" %% "twirl-compiler"     % "1.0.4" % "provided",
       "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided"
     ),

--- a/src/main/scala/fr/brouillard/gitbucket/announce/controller/AnnounceController.scala
+++ b/src/main/scala/fr/brouillard/gitbucket/announce/controller/AnnounceController.scala
@@ -7,7 +7,8 @@ import gitbucket.core.servlet.Database
 import gitbucket.core.util.AdminAuthenticator
 import jp.sf.amateras.scalatra.forms._
 import org.apache.commons.mail.{DefaultAuthenticator, HtmlEmail}
-import org.pegdown.PegDownProcessor
+import io.github.gitbucket.markedj.Marked
+import io.github.gitbucket.markedj.Options
 import org.slf4j.LoggerFactory
 
 class AnnounceController extends AnnounceControllerBase
@@ -58,7 +59,10 @@ trait AnnounceControllerBase extends ControllerBase with AccountService {
       email.setCharset("UTF-8")
       email.setSubject(form.subject)
 
-      email.setHtmlMsg(new PegDownProcessor().markdownToHtml(form.content))
+      val opts = new Options();
+      opts.setSanitize(true);
+
+      email.setHtmlMsg(Marked.marked(form.content, opts))
 
       logger.info("sending email: {}", form.content)
       val database = Database()


### PR DESCRIPTION
`Send Announce` clicked `java.lang.NoClassDefFoundError: org/pegdown/PegDownProcessor` error.

gitbucket3.7 is...
> Markdown processor has been switched to markedj from pegdown
